### PR TITLE
Fix RISP_data function

### DIFF
--- a/examples/all_bin_scenario.py
+++ b/examples/all_bin_scenario.py
@@ -176,7 +176,7 @@ if __name__ == "__main__":
     ############# RUN DIV BIN SIMUS #############
     # for div_bin in Div_bins.bins:
     for div_bin in Div_bins.bins[
-        :4
+        15:18
     ]:  # only running 4 div bins to demonstrate capability
         my_model, quantities = which_model(div_bin)
 

--- a/src/hisp/plamsa_data_handling/main.py
+++ b/src/hisp/plamsa_data_handling/main.py
@@ -110,12 +110,14 @@ class PlasmaDataHandling:
             elif bin.outer_bin:
                 folder = self.path_to_ROSP_data
                 offset_mb = 18
+            else:
+                offset_mb = 0
         else:
             offset_mb = 0
 
         t_rel = int(t_rel)
         # NOTE: what is the point of this test since it takes bin_index as an argument?
-        if div:
+        if div and offset_mb != 0:
             if 1 <= t_rel <= 9:
                 key = f"{folder}_1_9"
                 if key not in self._time_to_RISP_data.keys():


### PR DESCRIPTION
Previously, RISP_data function assigned flux values only to first wall sub bins and divertor bins that were on the inner and outer strike point. This means that the function broke when a Divbin on neither the inner or outer strike point was passed to RISP_data. 

Added capability to return correct RISP flux data for non-strike point Divbins. Note that this is a "quick fix" that relies on the offset_mb function, which should eventually be changed in accordance with issue #50.