### PR TITLE
Fix duplicate pulses bug

### DIFF
--- a/src/hisp/scenario.py
+++ b/src/hisp/scenario.py
@@ -189,8 +189,7 @@ class Scenario:
         Returns:
             the time at which the current pulse started
         """
-        current_pulse = self.get_pulse(t)
-        pulse_index = self.pulses.index(current_pulse)
+        pulse_index = self.get_row(t)
         return sum(
             [
                 pulse.nb_pulses * pulse.total_duration

--- a/test/test_scenario.py
+++ b/test/test_scenario.py
@@ -236,3 +236,17 @@ def test_reading_a_file():
         plt.plot(times[i : i + 2], np.ones_like(times[i : i + 2]), c=colors[i])
     # plt.xscale("log")
     # plt.show()
+
+
+def test_duplicate_objects():
+    my_scenario = Scenario([pulse1, pulse1])
+
+    t_1 = (pulse1.total_duration * pulse1.nb_pulses) / 2
+    t_2 = (
+        pulse1.total_duration * pulse1.nb_pulses
+        + (pulse2.total_duration * pulse2.nb_pulses) / 2
+    )
+    start_time_pulse_1 = my_scenario.get_time_start_current_pulse(t_1)
+    start_time_pulse_2 = my_scenario.get_time_start_current_pulse(t_2)
+    print(start_time_pulse_1, start_time_pulse_2)
+    assert start_time_pulse_1 != start_time_pulse_2


### PR DESCRIPTION
This PR fixes a bug which made it impossible to have the same `Pulse` instance multiple times in a `Scenario` and calling `get_time_start_current_pulse` because of the use of `index`

Instead, we use the method `get_row` that returns the index regardless of the instance.

+ added test that catches the bug