### PR TITLE
Fix risp index

### DIFF
--- a/src/hisp/bin.py
+++ b/src/hisp/bin.py
@@ -145,7 +145,7 @@ class DivBin:
             outer_bin: True if outer bin
         """
         inner_swept_bins = list(range(45, 64))
-        outer_swept_bins = list(range(18, 33))
+        outer_swept_bins = list(range(18, 32))
 
         if self.index in inner_swept_bins:
             self.inner_bin = True


### PR DESCRIPTION
Upon fixing data file formats, noticed that one index to identify if bin was on inner strike point was wrong. Fixed here. 