### PR TITLE
Cap stepsize differently for RISP

### DIFF
--- a/src/hisp/festim_models/mb_model.py
+++ b/src/hisp/festim_models/mb_model.py
@@ -277,7 +277,7 @@ def make_W_mb_model(
     my_model.settings = F.Settings(
         atol=1e10,
         rtol=1e-10,
-        max_iterations=1000,
+        max_iterations=30,
         final_time=final_time,
     )
 
@@ -748,7 +748,7 @@ def make_DFW_mb_model(
     my_model.settings = F.Settings(
         atol=1e10,
         rtol=1e-10,
-        max_iterations=1000,
+        max_iterations=30,
         final_time=final_time,
     )
 

--- a/src/hisp/festim_models/mb_model.py
+++ b/src/hisp/festim_models/mb_model.py
@@ -277,7 +277,7 @@ def make_W_mb_model(
     my_model.settings = F.Settings(
         atol=1e10,
         rtol=1e-10,
-        max_iterations=30,
+        max_iterations=100,  # the first timestep needs about 66 iterations....
         final_time=final_time,
     )
 

--- a/src/hisp/festim_models/mb_model.py
+++ b/src/hisp/festim_models/mb_model.py
@@ -318,9 +318,9 @@ def make_B_mb_model(
 
     vertices = np.concatenate(  # 1D mesh with extra refinement
         [
-            np.linspace(0, 5e-9, num=200),
-            np.linspace(5e-9, 1e-8, num=500),
-            np.linspace(1e-8, L, num=300),
+            np.linspace(0, 30e-9, num=500),
+            np.linspace(30e-9, 1e-7, num=500),
+            np.linspace(1e-7, L, num=500),
         ]
     )
     my_model.mesh = F.Mesh1D(vertices)
@@ -540,9 +540,9 @@ def make_B_mb_model(
 
     ############# Settings #############
     my_model.settings = F.Settings(
-        atol=1e10,
-        rtol=1e-8,
-        max_iterations=1000,
+        atol=1e8,
+        rtol=1e-10,
+        max_iterations=30,
         final_time=final_time,
     )
 

--- a/src/hisp/model.py
+++ b/src/hisp/model.py
@@ -157,10 +157,12 @@ class Model:
         if pulse.pulse_type == "RISP":
             # RISP has a special treatment
             time_real_risp_starts = (
-                89  # (s) relative time at which the real RISP starts
+                100  # (s) relative time at which the real RISP starts
             )
-            if relative_time < time_real_risp_starts:
+            if relative_time < time_real_risp_starts - 11:
                 value = 10  # s
+            elif relative_time < time_real_risp_starts + 1:
+                value = 0.01  # s
             else:
                 value = 1  # s
         else:
@@ -198,6 +200,12 @@ class Model:
                 # start of the next pulse
                 milestones.append(start_of_pulse + pulse.total_duration * (i + 1))
 
+                # add milestones 10 s before the end of the waiting period
+                assert pulse.total_duration - pulse.duration_no_waiting >= 10
+                milestones.append(start_of_pulse + pulse.total_duration * (i + 1) - 10)
+
+                # add milestones 2 s before the end of the waiting period
+                milestones.append(start_of_pulse + pulse.total_duration * (i + 1) - 2)
                 # start of the waiting period of this pulse
                 milestones.append(
                     start_of_pulse

--- a/src/hisp/model.py
+++ b/src/hisp/model.py
@@ -154,11 +154,15 @@ class Model:
     def max_stepsize(self, t: float) -> float:
         pulse = self.scenario.get_pulse(t)
         relative_time = t - self.scenario.get_time_start_current_pulse(t)
+        if pulse.pulse_type == "RISP":
+            value = 0.3  # s
+        else:
+            value = pulse.duration_no_waiting / 10  # s
         return periodic_step_function(
             relative_time,
             period_on=pulse.duration_no_waiting,
             period_total=pulse.total_duration,
-            value=pulse.duration_no_waiting / 10,
+            value=value,
             value_off=None,
         )
 

--- a/src/hisp/model.py
+++ b/src/hisp/model.py
@@ -217,7 +217,7 @@ class Model:
 
                     # hack: a milestone right after to ensure the stepsize is small enough
                     milestones.append(
-                        t_begin_real_pulse + pulse.total_duration * i + 0.1
+                        t_begin_real_pulse + pulse.total_duration * i + 0.05
                     )
 
             # update the current time to the end of the current "sequence" of pulses

--- a/test/test_mb_model_festim.py
+++ b/test/test_mb_model_festim.py
@@ -9,7 +9,9 @@ import festim as F
 import pytest
 
 
-@pytest.mark.parametrize("temp", [400, lambda t: 400 + 1, lambda x, t: 400 + t - x[0]])
+@pytest.mark.parametrize(
+    "temp", [1000, lambda t: 1000 + 1, lambda x, t: 1000 + t - x[0]]
+)
 def test_mb_model(temp):
     """Builds a festim tungsten model, run it, and tests the output."""
     (mb_model, quantities) = make_W_mb_model(
@@ -34,7 +36,9 @@ def test_mb_model(temp):
         assert len(value.data) > 0
 
 
-@pytest.mark.parametrize("temp", [400, lambda t: 400 + 1, lambda x, t: 400 + t - x[0]])
+@pytest.mark.parametrize(
+    "temp", [1000, lambda t: 1000 + 1, lambda x, t: 1000 + t - x[0]]
+)
 def test_mb_model(temp):
     """Builds a festim boron model, run it, and tests the output."""
     (mb_model, quantities) = make_B_mb_model(
@@ -59,7 +63,9 @@ def test_mb_model(temp):
         assert len(value.data) > 0
 
 
-@pytest.mark.parametrize("temp", [400, lambda t: 400 + 1, lambda x, t: 400 + t - x[0]])
+@pytest.mark.parametrize(
+    "temp", [1000, lambda t: 1000 + 1, lambda x, t: 1000 + t - x[0]]
+)
 def test_mb_model(temp):
     """Builds a festim tungsten model, run it, and tests the output."""
     (mb_model, quantities) = make_DFW_mb_model(

--- a/test/test_mb_model_festim.py
+++ b/test/test_mb_model_festim.py
@@ -12,7 +12,7 @@ import pytest
 @pytest.mark.parametrize(
     "temp", [1000, lambda t: 1000 + 1, lambda x, t: 1000 + t - x[0]]
 )
-def test_mb_model(temp):
+def test_mb_W_model(temp):
     """Builds a festim tungsten model, run it, and tests the output."""
     (mb_model, quantities) = make_W_mb_model(
         temperature=temp,
@@ -40,7 +40,7 @@ def test_mb_model(temp):
 @pytest.mark.parametrize(
     "temp", [1000, lambda t: 1000 + 1, lambda x, t: 1000 + t - x[0]]
 )
-def test_mb_model(temp):
+def test_mb_model_B(temp):
     """Builds a festim boron model, run it, and tests the output."""
     (mb_model, quantities) = make_B_mb_model(
         temperature=temp,
@@ -68,7 +68,7 @@ def test_mb_model(temp):
 @pytest.mark.parametrize(
     "temp", [1000, lambda t: 1000 + 1, lambda x, t: 1000 + t - x[0]]
 )
-def test_mb_model(temp):
+def test_mb_model_DFW(temp):
     """Builds a festim tungsten model, run it, and tests the output."""
     (mb_model, quantities) = make_DFW_mb_model(
         temperature=temp,

--- a/test/test_mb_model_festim.py
+++ b/test/test_mb_model_festim.py
@@ -15,11 +15,11 @@ import pytest
 def test_mb_W_model(temp):
     """Builds a festim tungsten model, run it, and tests the output."""
     (mb_model, quantities) = make_W_mb_model(
-        temperature=temp,
-        deuterium_ion_flux=lambda _: 1e22,
-        deuterium_atom_flux=lambda _: 1e22,
-        tritium_ion_flux=lambda _: 1e22,
-        tritium_atom_flux=lambda _: 1e22,
+        temperature=1000,
+        deuterium_ion_flux=lambda _: 2e10,
+        deuterium_atom_flux=lambda _: 2e10,
+        tritium_ion_flux=lambda _: 2e10,
+        tritium_atom_flux=lambda _: 2e10,
         L=6e-3,
         final_time=50,
         folder=".",

--- a/test/test_mb_model_festim.py
+++ b/test/test_mb_model_festim.py
@@ -24,6 +24,7 @@ def test_mb_model(temp):
         final_time=50,
         folder=".",
     )
+    mb_model.settings.stepsize.initial_value = 1
 
     mb_model.initialise()
     mb_model.run()
@@ -51,6 +52,7 @@ def test_mb_model(temp):
         L=6e-3,
         folder=".",
     )
+    mb_model.settings.stepsize.initial_value = 1
 
     mb_model.initialise()
     mb_model.run()
@@ -78,6 +80,8 @@ def test_mb_model(temp):
         L=6e-3,
         folder=".",
     )
+
+    mb_model.settings.stepsize.initial_value = 1
 
     mb_model.initialise()
     mb_model.run()


### PR DESCRIPTION
This pull request includes several modifications to the `src/hisp/festim_models/mb_model.py`, `src/hisp/model.py`, and `test/test_mb_model_festim.py` files. These changes primarily focus on updating model settings, refining mesh vertices, and enhancing the handling of specific pulse types in the model. Additionally, the test cases have been updated to reflect these changes. The most important changes are summarized below:

### Model Settings and Mesh Refinement:

* [`src/hisp/festim_models/mb_model.py`](diffhunk://#diff-b482f0f6bb643ab37c1213d56df8c8c179d5ed86c39f935d95f4bb6f2f3bee0cL280-R280): Updated the `max_iterations` to 30 and adjusted the `atol` and `rtol` values for various model creation functions (`make_W_mb_model`, `make_B_mb_model`, `make_DFW_mb_model`). [[1]](diffhunk://#diff-b482f0f6bb643ab37c1213d56df8c8c179d5ed86c39f935d95f4bb6f2f3bee0cL280-R280) [[2]](diffhunk://#diff-b482f0f6bb643ab37c1213d56df8c8c179d5ed86c39f935d95f4bb6f2f3bee0cL321-R323) [[3]](diffhunk://#diff-b482f0f6bb643ab37c1213d56df8c8c179d5ed86c39f935d95f4bb6f2f3bee0cL543-R545) [[4]](diffhunk://#diff-b482f0f6bb643ab37c1213d56df8c8c179d5ed86c39f935d95f4bb6f2f3bee0cL751-R751)

### Pulse Handling Enhancements:

* [`src/hisp/model.py`](diffhunk://#diff-4ce7defb1399cd909237eef153bccc99c2d6d120111322e23bee8fc9a41b1834R157-R173): Added special handling for "RISP" pulses in the `max_stepsize` method, including setting specific step sizes and milestones for real RISP pulses. [[1]](diffhunk://#diff-4ce7defb1399cd909237eef153bccc99c2d6d120111322e23bee8fc9a41b1834R157-R173) [[2]](diffhunk://#diff-4ce7defb1399cd909237eef153bccc99c2d6d120111322e23bee8fc9a41b1834L176-R223)

### Test Case Updates:

* [`test/test_mb_model_festim.py`](diffhunk://#diff-c62a0ed9878aa4fc823abbce1150635ebc106c2d198a72bc02198a81fbd82c02L12-R15): Updated the test cases for different models (`test_mb_W_model`, `test_mb_model_B`, `test_mb_model_DFW`) to use a higher temperature value and set the initial step size value. [[1]](diffhunk://#diff-c62a0ed9878aa4fc823abbce1150635ebc106c2d198a72bc02198a81fbd82c02L12-R15) [[2]](diffhunk://#diff-c62a0ed9878aa4fc823abbce1150635ebc106c2d198a72bc02198a81fbd82c02R27) [[3]](diffhunk://#diff-c62a0ed9878aa4fc823abbce1150635ebc106c2d198a72bc02198a81fbd82c02L37-R43) [[4]](diffhunk://#diff-c62a0ed9878aa4fc823abbce1150635ebc106c2d198a72bc02198a81fbd82c02R55) [[5]](diffhunk://#diff-c62a0ed9878aa4fc823abbce1150635ebc106c2d198a72bc02198a81fbd82c02L62-R71) [[6]](diffhunk://#diff-c62a0ed9878aa4fc823abbce1150635ebc106c2d198a72bc02198a81fbd82c02R84-R85)