### PR TITLE
Remove error when time overshoots maximum time

### DIFF
--- a/src/hisp/scenario.py
+++ b/src/hisp/scenario.py
@@ -145,9 +145,11 @@ class Scenario:
             else:
                 current_time += phase_duration
 
-        raise ValueError(
-            f"Time t {t} is out of bounds of the scenario file. Valid times are t < {self.get_maximum_time()}"
+        warnings.warn(
+            f"Time t {t} is out of bounds of the scenario file. Valid times are t < {self.get_maximum_time()}",
+            UserWarning,
         )
+        return i
 
     def get_pulse(self, t: float) -> Pulse:
         """Returns the pulse at time t.

--- a/src/hisp/scenario.py
+++ b/src/hisp/scenario.py
@@ -129,7 +129,10 @@ class Scenario:
         return Scenario(pulses)
 
     def get_row(self, t: float) -> int:
-        """Returns the index of the pulse at time t.
+        """
+        Returns the index of the pulse at time t.
+        If t is greater than the maximum time in the scenario, a
+        warning is raised and the last pulse index is returned.
 
         Args:
             t: the time in seconds
@@ -152,7 +155,10 @@ class Scenario:
         return i
 
     def get_pulse(self, t: float) -> Pulse:
-        """Returns the pulse at time t.
+        """
+        Returns the pulse at time t.
+        If t is greater than the maximum time in the scenario, a
+        warning is raised and the last pulse is returned.
 
         Args:
             t: the time in seconds

--- a/test/test_mb_model_festim.py
+++ b/test/test_mb_model_festim.py
@@ -82,3 +82,50 @@ def test_mb_model(temp):
         assert isinstance(key, str)
         assert isinstance(value, F.TotalVolume)
         assert len(value.data) > 0
+
+
+def test_model_last_timestep_overshoot():
+
+    from hisp.scenario import Scenario, Pulse
+
+    pulse1 = Pulse(
+        pulse_type="FP",
+        nb_pulses=1,
+        ramp_up=0,
+        steady_state=50,
+        ramp_down=0,
+        waiting=0,
+        tritium_fraction=0.5,
+    )
+
+    scenario = Scenario([pulse1])
+
+    def fun(t):
+        scenario.get_pulse(t)
+        return None
+
+    (my_model, quantities) = make_DFW_mb_model(
+        temperature=1000,
+        deuterium_ion_flux=lambda _: 0,
+        deuterium_atom_flux=lambda _: 0,
+        tritium_ion_flux=lambda _: 0,
+        tritium_atom_flux=lambda _: 0,
+        final_time=50,
+        L=6e-3,
+        folder=".",
+    )
+
+    my_model.settings.stepsize.growth_factor = 1.2
+    my_model.settings.stepsize.cutback_factor = 0.9
+    my_model.settings.stepsize.target_nb_iterations = 4
+    my_model.settings.stepsize.max_stepsize = fun
+
+    my_model.initialise()
+
+    my_model.t.value = 49
+    my_model.settings.stepsize.value = 20
+    my_model.dt.value = 20
+
+    my_model.show_progress_bar = False
+
+    my_model.iterate()

--- a/test/test_mb_model_festim.py
+++ b/test/test_mb_model_festim.py
@@ -85,7 +85,14 @@ def test_mb_model(temp):
 
 
 def test_model_last_timestep_overshoot():
+    """
+    Test to check that a simulation can run even with max_stepsize calling "get_pulse"
+    at a timestep that is greater than the maximum time in the scenario.
 
+    See PR #77 for more details.
+    """
+
+    # Define a scenario with a single pulse
     from hisp.scenario import Scenario, Pulse
 
     pulse1 = Pulse(
@@ -100,10 +107,12 @@ def test_model_last_timestep_overshoot():
 
     scenario = Scenario([pulse1])
 
+    # Define a function that will be called by the model to get the pulse at each timestep
     def fun(t):
         scenario.get_pulse(t)
         return None
 
+    # Create a model
     (my_model, quantities) = make_DFW_mb_model(
         temperature=1000,
         deuterium_ion_flux=lambda _: 0,
@@ -115,17 +124,22 @@ def test_model_last_timestep_overshoot():
         folder=".",
     )
 
+    my_model.show_progress_bar = False  # Disable the progress bar
+
+    # give the stepsize adaptivity settings
     my_model.settings.stepsize.growth_factor = 1.2
     my_model.settings.stepsize.cutback_factor = 0.9
     my_model.settings.stepsize.target_nb_iterations = 4
+
+    # cap the stepsize with the function we created
     my_model.settings.stepsize.max_stepsize = fun
 
+    # Initialise the model
     my_model.initialise()
 
+    # Artificially set the next timestep to be greater than the final time
     my_model.t.value = 49
     my_model.settings.stepsize.value = 20
     my_model.dt.value = 20
-
-    my_model.show_progress_bar = False
 
     my_model.iterate()

--- a/test/test_scenario.py
+++ b/test/test_scenario.py
@@ -159,7 +159,7 @@ pulse2 = Pulse(
     [
         (0, pulse1),
         (6000, pulse2),
-        (1e5, None),
+        (1e5, pulse2),
         (pulse1.nb_pulses * pulse1.total_duration, pulse2),
     ],
 )
@@ -167,13 +167,9 @@ def test_get_pulse(t, expected_pulse):
 
     my_scenario = Scenario([pulse1, pulse2])
 
-    if expected_pulse is None:
-        with pytest.raises(ValueError):
-            my_scenario.get_pulse(t=t)
-    else:
-        pulse = my_scenario.get_pulse(t=t)
-        print(pulse.pulse_type)
-        assert pulse == expected_pulse
+    pulse = my_scenario.get_pulse(t=t)
+    print(pulse.pulse_type)
+    assert pulse == expected_pulse
 
 
 @pytest.mark.parametrize("t, expected_pulse", [(100, pulse1)])


### PR DESCRIPTION
This pull request includes changes to improve error handling and add a new test case. The most important changes include modifying the `get_row` method in `src/hisp/scenario.py` to use a warning instead of raising an error, and adding a new test case in `test/test_mb_model_festim.py` to check for model overshoot at the last timestep.

Error handling improvements:

* [`src/hisp/scenario.py`](diffhunk://#diff-9798db168e52c8c4051b6eec721f16c53a602a12786a33af0cd16b79e8a5c411L148-R152): Changed the `get_row` method to issue a `UserWarning` instead of raising a `ValueError` when the time `t` is out of bounds. This allows the method to return a value even when the time is out of bounds.

Testing enhancements:

* [`test/test_mb_model_festim.py`](diffhunk://#diff-c62a0ed9878aa4fc823abbce1150635ebc106c2d198a72bc02198a81fbd82c02R85-R131): Added a new test case `test_model_last_timestep_overshoot` to verify the behavior of the model when the last timestep overshoots. This test case initializes a scenario and model, sets the model parameters, and checks the iteration process.